### PR TITLE
refactor useResolvedThemes and remove unnecessary hook theme

### DIFF
--- a/packages/button/src/button.tsx
+++ b/packages/button/src/button.tsx
@@ -1,33 +1,39 @@
 import React from 'react';
 import { yoru } from '@yoru-ui/core';
-import { useGetThemes, useGetColorScheme, useGetSizes } from '@yoru-ui/themes';
+import { useResolvedThemes } from '@yoru-ui/themes';
 
-export interface ButtonDefaultProps {
-  variant?: 'solid' | 'outline' | 'ghost' | 'link';
+type ButtonThemeProps = {
+  variants?: 'solid' | 'outline' | 'ghost' | 'link';
   colorScheme?: 'default' | 'primary' | 'secondary' | 'danger';
-  size?: 'sm' | 'md' | 'lg';
+  sizes?: 'sm' | 'md' | 'lg';
+};
+export interface ButtonDefaultProps extends ButtonThemeProps {
   block?: boolean;
   className?: string;
   children?: React.ReactNode;
 }
 
 export const Button: React.FC<ButtonDefaultProps> = props => {
-  const { colorScheme = 'default', size = 'md', block = false, className, children } = props;
+  const {
+    colorScheme = 'default',
+    sizes = 'md',
+    block = false,
+    variants = 'solid',
+    className,
+    children,
+  } = props;
 
-  // controll button baseStyle
-  const styledButton = useGetThemes('Button');
+  const ButtonTheme: ButtonThemeProps = {
+    colorScheme,
+    sizes,
+    variants,
+  };
 
-  // controll button colorscheme
-  const buttonColors = useGetColorScheme('Button', colorScheme);
-
-  // controll button size
-  const buttonSize = useGetSizes('Button', size);
+  const buttonStyled = useResolvedThemes('Button', ButtonTheme as any);
 
   const buttonStyles = () => {
     return {
-      ...styledButton.baseStyle,
-      ...buttonColors,
-      ...buttonSize,
+      ...buttonStyled,
       width: block ? '100%' : 'auto',
     };
   };

--- a/packages/button/stories/button.stories.tsx
+++ b/packages/button/stories/button.stories.tsx
@@ -22,7 +22,7 @@ Basic.argTypes = {
       type: 'select',
     },
   },
-  size: {
+  sizes: {
     options: ['sm', 'md', 'lg'],
     control: {
       type: 'select',
@@ -31,12 +31,18 @@ Basic.argTypes = {
   block: {
     control: 'boolean',
   },
+  variants: {
+    options: ['solid', 'outline', 'ghost', 'link'],
+    control: {
+      type: 'select',
+    },
+  },
 };
 
 Basic.args = {
   children: 'Button',
   colorScheme: 'default',
-  size: 'md',
+  sizes: 'md',
   block: false,
 };
 

--- a/packages/themes/src/components/button.ts
+++ b/packages/themes/src/components/button.ts
@@ -1,4 +1,6 @@
-const baseStyle: React.CSSProperties = {
+import { YoruStyleProperties } from '@yoru-ui/core';
+
+const baseStyle: YoruStyleProperties = {
   display: 'inline-flex',
   alignItems: 'center',
   justifyContent: 'center',
@@ -51,18 +53,16 @@ const secondaryVariants = () => {
   };
 };
 
-const dangerVariants = () => {
-  return {
-    backgroundColor: 'red.500',
-    color: 'white',
-    _hover: {
-      background: 'red.600',
-    },
-  };
+const dangerVariants = {
+  backgroundColor: 'red.500',
+  color: 'white',
+  _hover: {
+    background: 'red.600',
+  },
 };
 
 // varians button
-const variants = {
+const colorScheme = {
   default: defaultVariants,
   primary: primaryVariants,
   secondary: secondaryVariants,
@@ -71,26 +71,25 @@ const variants = {
 
 // size button
 const sizes = {
-  // https://tailwindcss.com/docs/font-size
   sm: {
     height: '1.5rem',
-    fontSize: '0.75rem', // todo: make it dynamic we can use sm, md, lg, xl
+    fontSize: '0.75rem',
     padding: '0.25rem 0.75rem',
   },
   md: {
     height: '2rem',
-    fontSize: '0.875rem', // todo: make it dynamic we can use sm, md, lg, xl
+    fontSize: '0.875rem',
     padding: '0.25rem 1rem',
   },
   lg: {
     height: '2.5rem',
-    fontSize: '1rem', // todo: make it dynamic we can use sm, md, lg, xl
+    fontSize: '1rem',
     padding: '0.5rem 1.5rem',
   },
 };
 
 export default {
   baseStyle,
-  variants,
+  colorScheme,
   sizes,
 };

--- a/packages/themes/src/hook/index.tsx
+++ b/packages/themes/src/hook/index.tsx
@@ -1,29 +1,33 @@
 import theme, { setTheme as setYoruTheme, ThemeContext, getTheme, ThemeVariant } from '..';
-import { ThemeConfigProperties, VariantsProperties } from '../types';
+import { ThemeConfigProperties } from '../types';
 import { resolverStyleConfig } from '../utils/styled-config';
 import { useContext, useEffect, useState } from 'react';
 import { useTheme as GetTheme } from '@emotion/react';
 
-export const useGetThemes = (componentKey: string) => {
+export const useResolvedThemes = (componentKey: string, props: ThemeConfigProperties) => {
+  const { colorScheme, sizes, variants } = props;
+  const yoruThemes = GetTheme();
   const { components } = theme;
   const themeStyleConfig = components[componentKey] as ThemeConfigProperties;
   const getStyle = resolverStyleConfig(themeStyleConfig);
-  return getStyle;
-};
 
-export const useGetColorScheme = (componentKey: string, variantKey: string) => {
-  const Component = useGetThemes(componentKey);
-  const { variants } = Component;
-  const variant = variants[variantKey] as VariantsProperties;
-  const theme = GetTheme();
-  return variant(theme);
-};
+  // selector for get all baseStyle from theme
+  const getBaseStyled = getStyle.baseStyle;
+  // selector for get all colorScheme from theme
+  const colorSchemes = getStyle.colorScheme[colorScheme as any];
+  const getColorScheme =
+    typeof colorSchemes === 'function' ? colorSchemes(yoruThemes) : colorSchemes;
+  // selector for get all size from theme
+  const getSizes = getStyle.sizes[sizes as any];
+  // selector for get all variants from theme
+  const getVariants = getStyle.variants[variants as any];
 
-export const useGetSizes = (componentKey: string, sizeKey: string) => {
-  const Component = useGetThemes(componentKey);
-  const { sizes } = Component;
-  const size = sizes[sizeKey] as VariantsProperties;
-  return size;
+  return {
+    ...getBaseStyled,
+    ...getColorScheme,
+    ...getSizes,
+    ...getVariants,
+  };
 };
 
 export const useTheme = () => {

--- a/packages/themes/src/types/index.ts
+++ b/packages/themes/src/types/index.ts
@@ -6,6 +6,7 @@ export type ThemeConfigProperties = {
   baseStyle?: Dictionary;
   variants?: Dictionary;
   sizes?: Dictionary;
+  colorScheme?: Dictionary;
 };
 
 export type VariantsProperties = (props: any) => YoruStyleProperties;

--- a/packages/themes/src/utils/styled-config.ts
+++ b/packages/themes/src/utils/styled-config.ts
@@ -6,13 +6,15 @@ import { ThemeConfigProperties } from '../types';
  * @returns
  */
 export const resolverStyleConfig = (config: ThemeConfigProperties) => {
-  const { baseStyle, variants, sizes } = config;
+  const { baseStyle, colorScheme, sizes, variants } = config;
   const resolvedBaseStyle = baseStyle ? baseStyle : {};
-  const resolvedVariants = variants ? variants : {};
+  const resolvedColorScheme = colorScheme ? colorScheme : {};
   const resolvedSizes = sizes ? sizes : {};
+  const resolvedVariants = variants ? variants : {};
   return {
     baseStyle: resolvedBaseStyle,
-    variants: resolvedVariants,
+    colorScheme: resolvedColorScheme,
     sizes: resolvedSizes,
+    variants: resolvedVariants,
   };
 };


### PR DESCRIPTION
Previously we had many custom hooks for resolving themes like useGetTheme, useGetSize, useGetVariants, and useGetColorScheme. In this PR I removed some of those custom hooks and made them into one resolver or custom hook.